### PR TITLE
"isReadStream" and "isWriteStream" tests were rejecting valid streams

### DIFF
--- a/lib/neek.js
+++ b/lib/neek.js
@@ -67,5 +67,5 @@ function isWriteStream(obj) {
 }
 
 function isStream(obj) {
-  return obj && typeof obj.pipe === 'function';
+  return obj && (typeof obj.pipe === 'function' || typeof(obj) === 'string');
 }

--- a/lib/neek.js
+++ b/lib/neek.js
@@ -56,14 +56,16 @@ module.exports = {
 
 };
 
-function isReadStream(rs){
-  return isStream(rs, process.stdin, '_read');
+function isReadStream(obj) {
+  // some streams are readable but do not have `read()`, however
+  // we can reliably detect readability by testing for `resume()`
+  return obj && typeof obj.resume === 'function';
 }
 
-function isWriteStream(ws){
-  return isStream(ws, process.stdout, '_write');
+function isWriteStream(obj) {
+  return obj && typeof obj.write === 'function';
 }
 
-function isStream(st, sys, prop){
-  return st && (st === sys|| typeof(st[prop]) === 'function' || typeof(st) === 'string');
+function isStream(obj) {
+  return obj && typeof obj.pipe === 'function';
 }

--- a/lib/neek.js
+++ b/lib/neek.js
@@ -59,11 +59,11 @@ module.exports = {
 function isReadStream(obj) {
   // some streams are readable but do not have `read()`, however
   // we can reliably detect readability by testing for `resume()`
-  return obj && typeof obj.resume === 'function';
+  return isStream(obj) && typeof obj.resume === 'function';
 }
 
 function isWriteStream(obj) {
-  return obj && typeof obj.write === 'function';
+  return isStream(obj) && typeof obj.write === 'function';
 }
 
 function isStream(obj) {

--- a/lib/neek.js
+++ b/lib/neek.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var isString = require('lodash.isstring');
 
 var Transformer = require('./transform');
 var StringStream = require('./stream');
@@ -68,8 +69,4 @@ function isWriteStream(obj) {
 
 function isStream(obj) {
   return obj && typeof obj.pipe === 'function';
-}
-
-function isString(obj) {
-  return typeof(obj) === 'string';
 }

--- a/lib/neek.js
+++ b/lib/neek.js
@@ -7,22 +7,22 @@ module.exports = {
 
   unique: function unique(input, output, callback) {
 
-    if (!isReadStream(input)) {
+    if (!isReadStream(input) && !isString(input)) {
       throw new Error('No input stream specified!');
     }
 
-    if (!isWriteStream(output)) {
+    if (!isWriteStream(output) && !isString(output)) {
       throw new Error('No output stream specified!');
     }
 
-    if (typeof input === 'string') {
+    if (isString(input)) {
       input = fs.createReadStream(input);
     }
 
     var stream = null;
 
     if (output !== 'string') {
-      if (typeof output === 'string') {
+      if (isString(output)) {
         stream = fs.createWriteStream(output);
       } else {
         stream = output;
@@ -67,5 +67,9 @@ function isWriteStream(obj) {
 }
 
 function isStream(obj) {
-  return obj && (typeof obj.pipe === 'function' || typeof(obj) === 'string');
+  return obj && typeof obj.pipe === 'function';
+}
+
+function isString(obj) {
+  return typeof(obj) === 'string';
 }

--- a/lib/neek.js
+++ b/lib/neek.js
@@ -8,14 +8,6 @@ module.exports = {
 
   unique: function unique(input, output, callback) {
 
-    if (!isReadStream(input) && !isString(input)) {
-      throw new Error('No input stream specified!');
-    }
-
-    if (!isWriteStream(output) && !isString(output)) {
-      throw new Error('No output stream specified!');
-    }
-
     if (isString(input)) {
       input = fs.createReadStream(input);
     }
@@ -30,6 +22,14 @@ module.exports = {
       }
     } else {
       stream = new StringStream();
+    }
+
+    if (!isReadStream(input)) {
+      throw new Error('No input stream specified!');
+    }
+
+    if (!isWriteStream(stream)) {
+      throw new Error('No output stream specified!');
     }
 
     var transformer = new Transformer();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "farmhash": "^1.1.1",
     "hashes": "0.1.3",
+    "lodash.isstring": "^4.0.1",
     "minimist": "1.2.0",
     "readable-stream": "2.1.4"
   },


### PR DESCRIPTION
The stream object test methods were too aggressive and only allowed certain types of streams, isStream/isReadStream/isWriteStream were modified to allow for other valid types of streams.

I tested the new methods using a "[request](https://www.npmjs.com/package/request)" object as an input stream and "[csv-stream](https://www.npmjs.com/package/csv-stream)" as output stream.
